### PR TITLE
Improve performance of dataloader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch==1.9.0+cu111
-pytorch-lightning==1.4.2
+pytorch-lightning==1.5.1
 pandas==1.1.4
 pyarrow==4.0.0
 scikit-learn==0.23.2

--- a/src/data/sequence_module.py
+++ b/src/data/sequence_module.py
@@ -136,11 +136,11 @@ class SequenceDataModule(pl.LightningDataModule):
 
     def train_dataloader(self):
         return DataLoader(self.training_dataset, batch_size=1, shuffle=True, num_workers=self.num_workers,
-                          collate_fn=_batched_collate)
+                          collate_fn=_batched_collate, persistent_workers=True, pin_memory=True)
 
     def val_dataloader(self):
         return DataLoader(self.validation_dataset, batch_size=1, shuffle=False, num_workers=self.num_workers,
-                          collate_fn=_batched_collate)
+                          collate_fn=_batched_collate, persistent_workers=True, pin_memory=True)
 
     def test_dataloader(self):
         return self.val_dataloader()

--- a/src/utils/options.py
+++ b/src/utils/options.py
@@ -46,7 +46,6 @@ class TrainerOptions:
     weights_summary: Optional[str] = 'top'
     weights_save_path: Optional[str] = None
     num_sanity_val_steps: int = 2
-    truncated_bptt_steps: Optional[int] = None
     resume_from_checkpoint: Optional[str] = None
     profiler: Optional[Any] = None
     benchmark: bool = False
@@ -58,8 +57,7 @@ class TrainerOptions:
     auto_scale_batch_size: Any = False
     prepare_data_per_node: bool = True
     amp_backend: str = 'native'
-    amp_level: str = 'O2'
-    distributed_backend: Optional[str] = None
+    amp_level: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
See pytorch lightning thread for more detail on the version update: https://github.com/PyTorchLightning/pytorch-lightning/issues/10389

Here's some data I gathered on my local computer with NVIDIA RTX A6000
-- Current version
epoch 0: 7.45 it/s
epoch 1: 7.6 it/s
epoch 2: 7.6 it/s

-- Persistent worker
epoch 0: 7.45 it/s
epoch 1: 9.5 it/s
epoch 2: 9.5 it/s

-- Persistent worker + Pin memory
epoch 0: 7.6 it/s
epoch 1: 9.8 it/s
epoch 2: 9.8 it/s

You lose around 10 seconds because of the worker reset at the start of each epoch.

315 it per epoch * 300 epochs = 94 500 iterations
~ 3.5 hours for current version
~ 2.75 hours for Persistent workers
~ 2.68 hours for Persistent worker + Pin memory

Note that the faster the epoch are the bigger the difference will be since the persistent workers is a constant delay at the start of each epoch.